### PR TITLE
Adding ability to add options for google maps api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 bower_components/
 coverage/
 npm-debug.log
+*.sw[nop]

--- a/angular-geocomplete.js
+++ b/angular-geocomplete.js
@@ -19,6 +19,7 @@
         // #### Arguments
         //
         // + `cityName`: `String`
+        // + `options`:  (Optional )`Object` of options, see more: https://developers.google.com/maps/documentation/geocoding/intro#ComponentFiltering
         // + `callback`: (Optional) `Callback` function
         //
         // #### Returns
@@ -33,12 +34,12 @@
         // => ["San Diego, CA, United States", "San Andreas, CA, United States", ...]
         // ```
         //
-        cities: function (cityName, callback) {
+        cities: function (cityName, options, callback) {
           return $http.get(apiUrl, {
-            params: {
+            params: angular.extend({}, options, {
               address: cityName,
               sensor: false
-            }
+            })
           }).then(function (res) {
             var addresses = [];
 
@@ -64,7 +65,8 @@
         //
         // #### Arguments
         //
-        // + `cityName`: An `String` with the city/place name
+        // + `cityName`: A `String` with the city/place name
+        // + `options`:  (Optional )`Object` of options, see more: https://developers.google.com/maps/documentation/geocoding/intro#ComponentFiltering
         // + `callback`: (Optional) `Callback` function.
         //
         // #### Returns
@@ -109,12 +111,12 @@
 	      //  }, ...]
         // ```
         //
-        citiesJSON: function (cityName, callback) {
+        citiesJSON: function (cityName, options, callback) {
           return $http.get(apiUrl, {
-            params: {
+            params: angular.extend({}, options, {
               address: cityName,
               sensor: false
-            }
+            })
           }).then(function (res) {
             var addresses = [];
 

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,9 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "demo",
+    "gulpfile.js",
+    "karma.conf.js"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-geocomplete",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "authors": [
     "Jose Luis Rivas <me@ghostbar.co>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-geocomplete",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Angular Factory to get GeoData on Cities from Google's API",
   "main": "angular-geocomplete.js",
   "repository": {

--- a/tests/angular-geocomplete.spec.js
+++ b/tests/angular-geocomplete.spec.js
@@ -88,11 +88,23 @@ describe('factory: geoComplete', function () {
     geoComplete = _geoComplete_;
 
     httpBackend.whenGET(apiUrl + '?address=Lake+Mary&sensor=false').respond(mockData);
+    httpBackend.whenGET(apiUrl + '?address=Lake+Mary&components=country:BR&sensor=false').respond(mockData);
   }));
 
   afterEach(function () {
     httpBackend.verifyNoOutstandingExpectation();
     httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('should return an array of matching city names using a promise and options', function () {
+    var responseData;
+
+    geoComplete.cities('Lake Mary', {components: 'country:BR'}).then(function (cities) {
+      responseData = cities;
+    });
+
+    httpBackend.expectGET(apiUrl + '?address=Lake+Mary&components=country:BR&sensor=false');
+    httpBackend.flush();
   });
 
   it('should search for a city', function () {
@@ -110,7 +122,7 @@ describe('factory: geoComplete', function () {
   it('should return an array of matching city names via callback', function () {
     var responseData;
 
-    geoComplete.cities('Lake Mary', function (cities) {
+    geoComplete.cities('Lake Mary', {}, function (cities) {
       responseData = cities;
     });
 
@@ -134,7 +146,7 @@ describe('factory: geoComplete', function () {
   it('should return matching city info as a JSON object via callback', function () {
     var responseData;
 
-    geoComplete.citiesJSON('Lake Mary', function (cities) {
+    geoComplete.citiesJSON('Lake Mary', {}, function (cities) {
       responseData = cities;
     });
 
@@ -153,5 +165,16 @@ describe('factory: geoComplete', function () {
     httpBackend.flush();
 
     expect(responseData.length).not.toBe(0);
+  });
+
+  it('should return matching city info as a JSON object using a promise and options', function () {
+    var responseData;
+
+    geoComplete.citiesJSON('Lake Mary', {components: 'country:BR'}).then(function (cities) {
+      responseData = cities;
+    });
+
+    httpBackend.expectGET(apiUrl + '?address=Lake+Mary&components=country:BR&sensor=false');
+    httpBackend.flush();
   });
 });


### PR DESCRIPTION
This PR adds the options parameter to be used to set more params on google maps request.

[See more about google maps options](https://developers.google.com/maps/documentation/geocoding/intro#ComponentFiltering)

I bump the version because the method signature changes.
